### PR TITLE
audiopolicy: make audio policy extensible

### DIFF
--- a/services/audiopolicy/common/include/policy.h
+++ b/services/audiopolicy/common/include/policy.h
@@ -22,7 +22,7 @@ static const audio_format_t gDynamicFormat = AUDIO_FORMAT_DEFAULT;
 
 // For mixed output and inputs, the policy will use max mixer sampling rates.
 // Do not limit sampling rate otherwise
-#define SAMPLE_RATE_HZ_MAX 192000
+#define SAMPLE_RATE_HZ_MAX 384000
 
 // Used when a client opens a capture stream, without specifying a desired sample rate.
 #define SAMPLE_RATE_HZ_DEFAULT 48000

--- a/services/audiopolicy/engine/interface/AudioPolicyManagerInterface.h
+++ b/services/audiopolicy/engine/interface/AudioPolicyManagerInterface.h
@@ -102,6 +102,14 @@ public:
     virtual audio_mode_t getPhoneState() const = 0;
 
     /**
+     * Set whether display-port is connected and is allowed to be used
+     * for voice usecases
+     *
+     * @param[in] connAndAllowed: if display-port is connected and can be used
+     */
+    virtual void setDpConnAndAllowedForVoice(bool connAndAllowed) = 0;
+
+    /**
      * Set Force Use config for a given usage.
      *
      * @param[in] usage for which a configuration shall be forced.

--- a/services/audiopolicy/enginedefault/src/Engine.cpp
+++ b/services/audiopolicy/enginedefault/src/Engine.cpp
@@ -40,6 +40,7 @@ namespace audio_policy
 Engine::Engine()
     : mManagerInterface(this),
       mPhoneState(AUDIO_MODE_NORMAL),
+      mDpConnAndAllowedForVoice(false),
       mApmObserver(NULL)
 {
     for (int i = 0; i < AUDIO_POLICY_FORCE_USE_CNT; i++) {
@@ -60,6 +61,11 @@ void Engine::setObserver(AudioPolicyManagerObserver *observer)
 status_t Engine::initCheck()
 {
     return (mApmObserver != NULL) ?  NO_ERROR : NO_INIT;
+}
+
+void Engine::setDpConnAndAllowedForVoice(bool connAndAllowed)
+{
+    mDpConnAndAllowedForVoice = connAndAllowed;
 }
 
 status_t Engine::setPhoneState(audio_mode_t state)
@@ -367,6 +373,10 @@ audio_devices_t Engine::getDeviceForStrategyInt(routing_strategy strategy,
             if (device) break;
             device = availableOutputDevicesType & AUDIO_DEVICE_OUT_USB_DEVICE;
             if (device) break;
+            if (getDpConnAndAllowedForVoice() && isInCall()) {
+                device = availableOutputDevicesType & AUDIO_DEVICE_OUT_AUX_DIGITAL;
+                if (device) break;
+            }
             if (!isInCall()) {
                 device = availableOutputDevicesType & AUDIO_DEVICE_OUT_USB_ACCESSORY;
                 if (device) break;
@@ -464,6 +474,15 @@ audio_devices_t Engine::getDeviceForStrategyInt(routing_strategy strategy,
                     break;
                 }
             }
+        }
+        // if display-port is connected and being used in voice usecase,
+        // play ringtone over speaker and display-port
+        if ((strategy == STRATEGY_SONIFICATION) && getDpConnAndAllowedForVoice()) {
+             uint32_t device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_AUX_DIGITAL;
+             if (device2 != AUDIO_DEVICE_NONE) {
+                 device |= device2;
+                 break;
+             }
         }
         // The second device used for sonification is the same as the device used by media strategy
         // FALL THROUGH

--- a/services/audiopolicy/enginedefault/src/Engine.h
+++ b/services/audiopolicy/enginedefault/src/Engine.h
@@ -78,6 +78,10 @@ private:
         {
             return mPolicyEngine->getPhoneState();
         }
+        virtual void setDpConnAndAllowedForVoice(bool connAndAllowed)
+        {
+            return mPolicyEngine->setDpConnAndAllowedForVoice(connAndAllowed);
+        }
         virtual status_t setForceUse(audio_policy_force_use_t usage,
                                      audio_policy_forced_cfg_t config)
         {
@@ -110,6 +114,12 @@ private:
         return is_state_in_call(mPhoneState);
     }
 
+    inline bool getDpConnAndAllowedForVoice() const
+    {
+        return mDpConnAndAllowedForVoice;
+    }
+
+    void setDpConnAndAllowedForVoice(bool connAndAllowed);
     status_t setPhoneState(audio_mode_t mode);
     audio_mode_t getPhoneState() const
     {
@@ -132,6 +142,8 @@ private:
             uint32_t outputDeviceTypesToIgnore) const;
     audio_devices_t getDeviceForInputSource(audio_source_t inputSource) const;
     audio_mode_t mPhoneState;  /**< current phone state. */
+    /* if display-port is connected and can be used for voip/voice */
+    bool mDpConnAndAllowedForVoice;
 
     /** current forced use configuration. */
     audio_policy_forced_cfg_t mForceUse[AUDIO_POLICY_FORCE_USE_CNT];

--- a/services/audiopolicy/managerdefault/AudioPolicyManager.h
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.h
@@ -390,7 +390,7 @@ protected:
         // when a device is disconnected, checks if an output is not used any more and
         // returns its handle if any.
         // transfers the audio tracks and effects from one output thread to another accordingly.
-        status_t checkOutputsForDevice(const sp<DeviceDescriptor>& devDesc,
+        virtual status_t checkOutputsForDevice(const sp<DeviceDescriptor>& devDesc,
                                        audio_policy_dev_state_t state,
                                        SortedVector<audio_io_handle_t>& outputs,
                                        const String8& address);


### PR DESCRIPTION
make function virtual or protected so that
they can be extended in custom audio policy.
Change-Id: Ida7992f6b327491fab1f4ea376e85e8eb34b89ca

audiopolicy: update APM to use custom audio policy configuration
Change-Id: I3161ff4fa41d37d0b761202f0b3a490d9c7e418e

audiopolicy: allow dp device selection for voice usecases
Change-Id: I13f1ddd0fd3655376d28a0ebe028d495fa2c6e5f

audiopolicy: follow-up change to support extended feature
Change-Id: Iddc14a3e2e61bc57f8637eae71e36cc21ce2d3e8

Change-Id: Ida7992f6b327491fab1f4ea376e85e8eb34b89ca