### PR TITLE
Use uint32_t instead of int to support 2G or bigger file

### DIFF
--- a/media/mtp/MtpDevice.cpp
+++ b/media/mtp/MtpDevice.cpp
@@ -516,7 +516,7 @@ MtpObjectHandle MtpDevice::sendObjectInfo(MtpObjectInfo* info) {
     return (MtpObjectHandle)-1;
 }
 
-bool MtpDevice::sendObject(MtpObjectHandle handle, int size, int srcFD) {
+bool MtpDevice::sendObject(MtpObjectHandle handle, uint32_t size, int srcFD) {
     std::lock_guard<std::mutex> lg(mMutex);
 
     if (mLastSendObjectInfoTransactionID + 1 != mTransactionID ||
@@ -529,7 +529,7 @@ bool MtpDevice::sendObject(MtpObjectHandle handle, int size, int srcFD) {
     if (sendRequest(MTP_OPERATION_SEND_OBJECT)) {
         mData.setOperationCode(mRequest.getOperationCode());
         mData.setTransactionID(mRequest.getTransactionID());
-        const int writeResult = mData.write(mRequestOut, mPacketDivisionMode, srcFD, size);
+        const uint32_t writeResult = mData.write(mRequestOut, mPacketDivisionMode, srcFD, size);
         const MtpResponseCode ret = readResponse();
         return ret == MTP_RESPONSE_OK && writeResult > 0;
     }

--- a/media/mtp/MtpDevice.h
+++ b/media/mtp/MtpDevice.h
@@ -104,7 +104,7 @@ public:
     MtpObjectInfo*          getObjectInfo(MtpObjectHandle handle);
     void*                   getThumbnail(MtpObjectHandle handle, int& outLength);
     MtpObjectHandle         sendObjectInfo(MtpObjectInfo* info);
-    bool                    sendObject(MtpObjectHandle handle, int size, int srcFD);
+    bool                    sendObject(MtpObjectHandle handle, uint32_t size, int srcFD);
     bool                    deleteObject(MtpObjectHandle handle);
     MtpObjectHandle         getParent(MtpObjectHandle handle);
     MtpStorageID            getStorageID(MtpObjectHandle handle);


### PR DESCRIPTION
MtpDevice#sendObject is using int to define object size,
if the object size is bigger than 2GB, the size will be type-cast to
a negative number in MtpDevice#sendObject. And it will cause a endless
loop in MtpDataPacket#write until DUT auto reboot.

And JNI api android_mtp_MtpDevice_send_object requires that object
size must be uint32_t , so MtpDevice#sendObject works well after its
size parameter is changed from int to uint32_t.

Test: manual - connect Android device to Android Automotive
Test: manual - select MTP/File Transfer in android device
Test: manual - copy a file which is bigger than 2GB from automotive to the android device.

bug: 115451170
Change-Id: I65b89f195ef0527a802bccefc90721e536683b87
Signed-off-by: robinz1x <robinx.zhang@intel.com>
Signed-off-by: Guobin Zhang <guobin.zhang@intel.com>
Signed-off-by: mydongistiny <jaysonedson@gmail.com>